### PR TITLE
save audio settings via local storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     <script src="script/game.js"></script>
     <script src="models/start.class.js"></script>
 </head>
-<body onload="initStartScreen(); checkBrowser(); bindBitsPressEvent(); checkDevelopment();">
+<body onload="initStartScreen(); checkBrowser(); bindBitsPressEvent(); checkDevelopment(); loadAudioSettings();">
 <div class="mobileWarning">
     <h1>Please turn your cell phone to landscape format</h1>
     <div>

--- a/script/game.js
+++ b/script/game.js
@@ -15,6 +15,7 @@ function startBackgroundMusic() {
 
 function setVolume(volume) {
     backgroundMusic.volume = volume;
+    localStorage.setItem('volume', volume);
 }
 
 function stopBackgroundMusic() {
@@ -179,6 +180,35 @@ function changeAudio() {
         startBackgroundMusic();
         audioButton.src = 'img/controll-icons/audio_on.svg';
         audioButtonMobile.src = 'img/controll-icons/audio_on.svg';
+    }
+    localStorage.setItem('audio', audio);
+}
+
+
+function loadAudioSettings() {
+    const savedAudioSetting = localStorage.getItem('audio');
+    const savedVolume = localStorage.getItem('volume');
+
+    if (savedAudioSetting !== null) {
+        audio = savedAudioSetting === 'true';
+        let audioButton = document.getElementById('audioButton');
+        let audioButtonMobile = document.getElementById('audioButtonMobile');
+        if (audio) {
+            backgroundMusic.loop = true;
+            startBackgroundMusic();
+            audioButton.src = 'img/controll-icons/audio_on.svg';
+            audioButtonMobile.src = 'img/controll-icons/audio_on.svg';
+        } else {
+            backgroundMusic.loop = false;
+            stopBackgroundMusic();
+            audioButton.src = 'img/controll-icons/audio_off.svg';
+            audioButtonMobile.src = 'img/controll-icons/audio_off.svg';
+        }
+    }
+
+    if (savedVolume !== null) {
+        backgroundMusic.volume = parseFloat(savedVolume);
+        document.getElementById('volumeSlider').value = savedVolume;
     }
 }
 


### PR DESCRIPTION
This pull request introduces enhancements to the audio settings functionality by adding persistence through local storage. The key changes include adding a new function to load audio settings from local storage and updating relevant functions to save settings.

### Enhancements to audio settings:

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L36-R36): Added `loadAudioSettings()` to the `onload` attribute of the `<body>` tag to initialize audio settings when the page loads.
* [`script/game.js`](diffhunk://#diff-feee6361580fa71f2bef51a7741374ddc817dca12159f4b3dcefc2dfd5c70a9fR18): Updated `setVolume` function to save the volume level to local storage.
* [`script/game.js`](diffhunk://#diff-feee6361580fa71f2bef51a7741374ddc817dca12159f4b3dcefc2dfd5c70a9fR184-R212): Enhanced `changeAudio` function to save the audio state to local storage.
* [`script/game.js`](diffhunk://#diff-feee6361580fa71f2bef51a7741374ddc817dca12159f4b3dcefc2dfd5c70a9fR184-R212): Added `loadAudioSettings` function to retrieve and apply saved audio settings (audio state and volume) from local storage when the game initializes.